### PR TITLE
Fix mem_limit handling in compose conversion.

### DIFF
--- a/container_transform/compose.py
+++ b/container_transform/compose.py
@@ -158,7 +158,7 @@ class ComposeTransformer(BaseTransformer):
         Transform the memory into bytes
 
         :param memory: Compose memory definition. (1g, 24k)
-        :type memory: str
+        :type memory: memory string or integer
         :return: The memory in bytes
         :rtype: int
         """
@@ -167,6 +167,10 @@ class ComposeTransformer(BaseTransformer):
 
         def rshift(num, shift):
             return num >> shift
+
+        if isinstance(memory, int):
+            # Memory was specified as an integer, meaning it is in bytes
+            memory = '{}b'.format(memory)
 
         bit_shift = {
             'g': {'func': lshift, 'shift': 30},

--- a/container_transform/tests/docker-compose.yml
+++ b/container_transform/tests/docker-compose.yml
@@ -61,6 +61,12 @@ logs:
     - '/var/log/apache/:ro'
     - '/var/log/syslog/'
     - '/should:/be:/ommitted'
+web3:
+  image: me/myapp
+  mem_limit: 1024
+  entrypoint: uwsgi
+  command: --json uwsgi.json
+  cpu_shares: 200
 dummy:
   image: me/myapp
   entrypoint: ["noop", "param0"]


### PR DESCRIPTION
When the `mem_limit` has no suffix, it should be considered to be in bytes.
- Added test.
