### PR TITLE
Simple handling of '2.0' compose format.

### DIFF
--- a/container_transform/compose.py
+++ b/container_transform/compose.py
@@ -29,7 +29,7 @@ class ComposeTransformer(BaseTransformer):
         if filename:
             self._filename = filename
             stream = self._read_file(filename)
-            self.stream_version = int(stream.get('version', '1'))
+            self.stream_version = float(stream.get('version', '1'))
 
             if self.stream_version > 1:
                 self.stream = stream.get('services')

--- a/container_transform/tests/composev2.0.yml
+++ b/container_transform/tests/composev2.0.yml
@@ -1,0 +1,17 @@
+version: '2.0'
+services:
+  web:
+    build: .
+    ports:
+     - "5000:5000"
+    volumes:
+     - .:/code
+    labels:
+      com.example.description: "Accounting webapp"
+      com.example.department: "Finance"
+      com.example.label-with-empty-value: ""
+    logging:
+      driver: gelf
+      options:
+        tag: web
+        gelf-address: "udp://127.0.0.1:12900"

--- a/container_transform/tests/composev2.0_output.service
+++ b/container_transform/tests/composev2.0_output.service
@@ -1,0 +1,22 @@
+# web.service #######################################################################
+[Unit]
+Description=Web
+After=docker.service 
+Requires=docker.service 
+
+[Service]
+ExecStartPre=-/usr/bin/docker kill web
+ExecStartPre=-/usr/bin/docker rm web
+ExecStartPre=/usr/bin/docker pull <image>
+ExecStart=/usr/bin/docker run \
+    --name web \
+    -p 5000:5000 \
+    -v .:/code \
+    --log-driver=gelf \
+    --log-opt gelf-address=udp://127.0.0.1:12900 \
+    --log-opt tag=web \
+    --label com.example.department="Finance" \
+    --label com.example.description="Accounting webapp" \
+    --label com.example.label-with-empty-value="" \
+    <image> 
+ExecStop=/usr/bin/docker stop web

--- a/container_transform/tests/converter_tests.py
+++ b/container_transform/tests/converter_tests.py
@@ -68,3 +68,15 @@ class ConverterTests(TestCase):
 
         output_want = open(output_filename, 'r').read()
         self.assertEqual(output, output_want)
+
+    def test_compose_converter_v2_0(self):
+        self.maxDiff = None
+
+        filename = './container_transform/tests/composev2.0.yml'
+        output_filename = './container_transform/tests/composev2.0_output.service'
+        conv = Converter(filename, 'compose', 'systemd')
+
+        output = conv.convert()
+
+        output_want = open(output_filename, 'r').read()
+        self.assertEqual(output, output_want)


### PR DESCRIPTION
Docker compose now supports '2.0' as the version string, so we now use a
float rather than an int type cast here.

Small sanity test added here as well.
