### PR TITLE
local testing makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+build:
+	docker build -t container-transform .
+
+test: build test-compose-to-ecs test-ecs-to-compose test-compose-to-systemd test-ecs-to-systemd
+
+test-compose-to-ecs:
+	docker run --rm -w /container-transform -i container-transform \
+		container_transform/tests/docker-compose.yml -v
+
+test-ecs-to-compose:
+	docker run --rm -w /container-transform -i container-transform \
+		container_transform/tests/task.json --input-type ecs --output-type compose
+
+test-compose-to-systemd:
+	docker run --rm -w /container-transform -i container-transform \
+		container_transform/tests/docker-compose.yml -v --output-type systemd
+
+test-ecs-to-systemd:
+	docker run --rm -w /container-transform -i container-transform \
+		container_transform/tests/task.json --input-type ecs --output-type systemd


### PR DESCRIPTION
Makefile helps for easier testing in the container locally. Runs the same tasks as Travis. Not super important, but helped me debug some changes.