### PR TITLE
Compose: Pass thru list types

### DIFF
--- a/container_transform/chronos.py
+++ b/container_transform/chronos.py
@@ -298,7 +298,9 @@ class ChronosTransformer(BaseTransformer):
         return ' '.join(command)
 
     def emit_command(self, command):
-        return command.split()
+        if isinstance(command, str):
+            command = command.split()
+        return command
 
     def ingest_entrypoint(self, entrypoint):
         return entrypoint

--- a/container_transform/compose.py
+++ b/container_transform/compose.py
@@ -215,16 +215,16 @@ class ComposeTransformer(BaseTransformer):
         return environment
 
     def ingest_command(self, command):
-        if isinstance(command, list):
-            command = ' '.join(command)
+        if isinstance(command, str):
+            command = command.split()
         return command
 
     def emit_command(self, command):
         return command
 
     def ingest_entrypoint(self, entrypoint):
-        if isinstance(entrypoint, list):
-            entrypoint = ' '.join(entrypoint)
+        if isinstance(entrypoint, str):
+            entrypoint = entrypoint.split()
         return entrypoint
 
     def emit_entrypoint(self, entrypoint):

--- a/container_transform/ecs.py
+++ b/container_transform/ecs.py
@@ -198,8 +198,8 @@ class ECSTransformer(BaseTransformer):
         return ' '.join(entrypoint)
 
     def emit_entrypoint(self, entrypoint):
-        if isinstance(command, str):
-            command = command.split()
+        if isinstance(entrypoint, str):
+            entrypoint = entrypoint.split()
         return entrypoint
 
     def ingest_volumes_from(self, volumes_from):

--- a/container_transform/ecs.py
+++ b/container_transform/ecs.py
@@ -190,13 +190,17 @@ class ECSTransformer(BaseTransformer):
         return ' '.join(command)
 
     def emit_command(self, command):
-        return command.split()
+        if isinstance(command, str):
+            command = command.split()
+        return command
 
     def ingest_entrypoint(self, entrypoint):
         return ' '.join(entrypoint)
 
     def emit_entrypoint(self, entrypoint):
-        return entrypoint.split()
+        if isinstance(command, str):
+            command = command.split()
+        return entrypoint
 
     def ingest_volumes_from(self, volumes_from):
         return [vol['sourceContainer'] for vol in volumes_from]

--- a/container_transform/kubernetes.py
+++ b/container_transform/kubernetes.py
@@ -336,7 +336,9 @@ class KubernetesTransformer(BaseTransformer):
         return ' '.join(command)
 
     def emit_command(self, command):
-        return command.split()
+        if isinstance(command, str):
+            command = command.split()
+        return command
 
     def ingest_entrypoint(self, entrypoint):
         return ' '.join(entrypoint)

--- a/container_transform/marathon.py
+++ b/container_transform/marathon.py
@@ -302,7 +302,9 @@ class MarathonTransformer(BaseTransformer):
         return ' '.join(command)
 
     def emit_command(self, command):
-        return command.split()
+        if isinstance(command, str):
+            command = command.split()
+        return command
 
     def ingest_entrypoint(self, entrypoint):
         return entrypoint

--- a/container_transform/systemd.py
+++ b/container_transform/systemd.py
@@ -145,6 +145,8 @@ class SystemdTransformer(BaseTransformer):
         pass
 
     def emit_command(self, command):
+        if isinstance(command, list):
+            command = ' '.join(command)
         return command
 
     def ingest_entrypoint(self, entrypoint):

--- a/container_transform/tests/docker-compose.yml
+++ b/container_transform/tests/docker-compose.yml
@@ -72,3 +72,6 @@ dummy:
   image: me/myapp
   entrypoint: ["noop", "param0"]
   command: ["param2", "param1"]
+nested:
+  image: me/myapp
+  command: ["sh", "-c", "make test ; make run"]


### PR DESCRIPTION
There's an edge case with Docker Compose `command` entries that the current code will break.

`command: ["bash", "-c", "cmd one ; cmd two"]` is supposed to generate a command similar to: `bash -c "cmd one ; cmd two"`.

This ought to generate an ECS task command form of:
```json
"command": [
  "sh",
  "-c",
  "make test ; make run"
]
```

but instead, it generates

```json
"command": [
  "sh",
  "-c",
  "make",
  "test",
  ";",
  "make",
  "run"
]
```

Which fails on ECS. This _at least_ fixes the issue I'm seeing, but I'm not entirely aware what else could break.
