### PR TITLE
Fix command splitting and joining when an argument contains spaces

### DIFF
--- a/container_transform/chronos.py
+++ b/container_transform/chronos.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import shlex
 
 from datetime import datetime
 
@@ -295,10 +296,10 @@ class ChronosTransformer(BaseTransformer):
         return sorted(sorted_by_value, key=lambda p: p.get('name'))
 
     def ingest_command(self, command):
-        return ' '.join(command)
+        return self._list2cmdline(command)
 
     def emit_command(self, command):
-        return command.split()
+        return shlex.split(command)
 
     def ingest_entrypoint(self, entrypoint):
         return entrypoint

--- a/container_transform/compose.py
+++ b/container_transform/compose.py
@@ -216,7 +216,7 @@ class ComposeTransformer(BaseTransformer):
 
     def ingest_command(self, command):
         if isinstance(command, list):
-            command = ' '.join(command)
+            return self._list2cmdline(command)
         return command
 
     def emit_command(self, command):
@@ -224,7 +224,7 @@ class ComposeTransformer(BaseTransformer):
 
     def ingest_entrypoint(self, entrypoint):
         if isinstance(entrypoint, list):
-            entrypoint = ' '.join(entrypoint)
+            return self._list2cmdline(entrypoint)
         return entrypoint
 
     def emit_entrypoint(self, entrypoint):

--- a/container_transform/ecs.py
+++ b/container_transform/ecs.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 from copy import copy
+import shlex
 
 from .schema import TransformationTypes
 from .transformer import BaseTransformer
@@ -187,16 +188,16 @@ class ECSTransformer(BaseTransformer):
         return output
 
     def ingest_command(self, command):
-        return ' '.join(command)
+        return self._list2cmdline(command)
 
     def emit_command(self, command):
-        return command.split()
+        return shlex.split(command)
 
     def ingest_entrypoint(self, entrypoint):
-        return ' '.join(entrypoint)
+        return self._list2cmdline(entrypoint)
 
     def emit_entrypoint(self, entrypoint):
-        return entrypoint.split()
+        return shlex.split(entrypoint)
 
     def ingest_volumes_from(self, volumes_from):
         return [vol['sourceContainer'] for vol in volumes_from]

--- a/container_transform/kubernetes.py
+++ b/container_transform/kubernetes.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 
 from copy import deepcopy
 from functools import reduce
@@ -333,16 +334,16 @@ class KubernetesTransformer(BaseTransformer):
         return [{'name': k, 'value': v} for k, v in environment.items()]
 
     def ingest_command(self, command):
-        return ' '.join(command)
+        return self._list2cmdline(command)
 
     def emit_command(self, command):
-        return command.split()
+        return shlex.split(command)
 
     def ingest_entrypoint(self, entrypoint):
-        return ' '.join(entrypoint)
+        return self._list2cmdline(entrypoint)
 
     def emit_entrypoint(self, entrypoint):
-        return entrypoint.split()
+        return shlex.split(entrypoint)
 
     @staticmethod
     def _build_volume_name(hostpath):

--- a/container_transform/marathon.py
+++ b/container_transform/marathon.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+import shlex
 
 from copy import deepcopy
 from functools import reduce
@@ -299,10 +300,10 @@ class MarathonTransformer(BaseTransformer):
         return environment
 
     def ingest_command(self, command):
-        return ' '.join(command)
+        return self._list2cmdline(command)
 
     def emit_command(self, command):
-        return command.split()
+        return shlex.split(command)
 
     def ingest_entrypoint(self, entrypoint):
         return entrypoint

--- a/container_transform/tests/compose_tests.py
+++ b/container_transform/tests/compose_tests.py
@@ -118,3 +118,17 @@ class ComposeTransformerTests(TestCase):
             self.transformer.emit_cpu(cpu),
             cpu
         )
+
+    def test_ingest_command_list(self):
+        """
+        Test .ingest_command() should respect that list items are single command args
+        """
+        command = [
+            "/bin/echo",
+            "Hello world"
+        ]
+
+        self.assertEqual(
+            self.transformer.ingest_command(command),
+            "/bin/echo 'Hello world'"
+        )

--- a/container_transform/tests/ecs_tests.py
+++ b/container_transform/tests/ecs_tests.py
@@ -46,3 +46,25 @@ class ECSTransformerTests(TestCase):
             self.transformer.emit_cpu(cpu),
             cpu
         )
+
+    def test_command_list(self):
+        """
+        Test .ingest_command() should respect that list items are single command args
+        Test .emit_command() should split correctly if an argument contains a space
+        """
+        command = [
+            "/bin/echo",
+            "Hello world"
+        ]
+
+        self.assertEqual(
+            self.transformer.ingest_command(command),
+            "/bin/echo 'Hello world'"
+        )
+
+        command = "/bin/echo 'Hello world'"
+
+        self.assertEqual(
+            self.transformer.emit_command(command),
+            ["/bin/echo", "Hello world"]
+        )

--- a/container_transform/tests/k8s_tests/dns-compose.yaml
+++ b/container_transform/tests/k8s_tests/dns-compose.yaml
@@ -9,7 +9,7 @@ services:
     volumes:
     - /usr/share/ca-certificates:/etc/ssl/certs
   healthz:
-    command: -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
+    command: -cmd="nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null"
       -port=8080
     cpu_shares: 10.24
     image: gcr.io/google_containers/exechealthz:1.0

--- a/container_transform/tests/k8s_tests/dns-k8s-out.yaml
+++ b/container_transform/tests/k8s_tests/dns-k8s-out.yaml
@@ -39,10 +39,7 @@ spec:
         - mountPath: /etc/ssl/certs
           name: usr-share-ca-certificates
       - args:
-        - -cmd=nslookup
-        - kubernetes.default.svc.cluster.local
-        - 127.0.0.1
-        - '>/dev/null'
+        - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
         - -port=8080
         image: gcr.io/google_containers/exechealthz:1.0
         name: healthz

--- a/container_transform/tests/k8s_tests/dns.yaml
+++ b/container_transform/tests/k8s_tests/dns.yaml
@@ -141,7 +141,7 @@ spec:
             cpu: 10m
             memory: 20Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
+        - -cmd="nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null"
         - -port=8080
         ports:
         - containerPort: 8080

--- a/container_transform/transformer.py
+++ b/container_transform/transformer.py
@@ -1,3 +1,4 @@
+import shlex
 from abc import ABCMeta, abstractmethod
 
 """The SCHEMA defines the argument format the .ingest_*() and .emit_*()
@@ -46,6 +47,21 @@ class BaseTransformer(object, metaclass=ABCMeta):
         normalized_keys = transformer.ingest_containers()
 
     """
+    @staticmethod
+    def _list2cmdline(commands):
+        def quote(cmd):
+            """
+            Make sure that each cmd in command list will be treated as a single token
+            :param cmd: str
+            :return:
+            """
+            if len(shlex.split(cmd)) == 1:
+                # Already a single token, do nothing
+                return cmd
+            else:
+                return shlex.quote(cmd)
+
+        return ' '.join(quote(cmd) for cmd in commands)
 
     def _read_file(self, filename):
         """

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ def get_version():
     else:
         raise RuntimeError('Unable to find version string in {0}.'.format(VERSION_FILE))
 
+
 install_requires = [
     'PyYAML>=3.10,<4',
     'Jinja2>=2.7.0',


### PR DESCRIPTION
At the moment ECS and compose transformers performs a "dumb" argument splitting.

This means that the following compose entrypoint:
```
entrypoint: ['/bin/echo', 'Hello world']
```
gets incorrectly transformed into `/bin/echo hello world` which fails as echo only expects 1 argument.

conversely ECS emits `'/bin/echo "Hello world"` as 
 ```
"entryPoint": [
                "/bin/echo",
                "\"Hello",
                "world\""
            ]
```
This PR fixes these and adds tests for the failure mode.