### PR TITLE
Fix variable substitution issue with compose

### DIFF
--- a/container_transform/compose.py
+++ b/container_transform/compose.py
@@ -205,13 +205,17 @@ class ComposeTransformer(BaseTransformer):
         if type(environment) is list:
             for kv in environment:
                 index = kv.find('=')
-                output[str(kv[:index])] = str(kv[index + 1:])
+                output[str(kv[:index])] = str(kv[index + 1:]).replace('$$', '$')
         if type(environment) is dict:
             for key, value in environment.items():
-                output[str(key)] = str(value)
+                output[str(key)] = str(value).replace('$$', '$')
         return output
 
     def emit_environment(self, environment):
+        # Use double-dollar and avoid vairable substitution. Reference,
+        # https://docs.docker.com/compose/compose-file/compose-file-v2
+        for key, value in environment.items():
+            environment[key] = str(value).replace('$', '$$')
         return environment
 
     def ingest_command(self, command):

--- a/container_transform/tests/compose_tests.py
+++ b/container_transform/tests/compose_tests.py
@@ -119,6 +119,34 @@ class ComposeTransformerTests(TestCase):
             cpu
         )
 
+    def test_ingest_environment(self):
+        environment = {
+            'DB_PAS': 'po$$tgres',
+            'DB_USER': 'postgres'
+        }
+        environment_exp = {
+            'DB_PAS': 'po$tgres',
+            'DB_USER': 'postgres'
+        }
+        self.assertEqual(
+            self.transformer.ingest_environment(environment),
+            environment_exp
+        )
+
+    def test_emit_environment(self):
+        environment = {
+            'DB_PAS': 'po$tgres',
+            'DB_USER': 'postgres'
+        }
+        environment_exp = {
+            'DB_PAS': 'po$$tgres',
+            'DB_USER': 'postgres'
+        }
+        self.assertEqual(
+            self.transformer.emit_environment(environment),
+            environment
+        )
+
     def test_ingest_command_list(self):
         """
         Test .ingest_command() should respect that list items are single command args

--- a/container_transform/tests/compose_tests.py
+++ b/container_transform/tests/compose_tests.py
@@ -144,7 +144,7 @@ class ComposeTransformerTests(TestCase):
         }
         self.assertEqual(
             self.transformer.emit_environment(environment),
-            environment
+            environment_exp
         )
 
     def test_ingest_command_list(self):

--- a/container_transform/tests/docker-compose.yml
+++ b/container_transform/tests/docker-compose.yml
@@ -9,7 +9,7 @@ worker:
     - BROKER_URL=redis://redis:6379/0
     - DB_HOST=db
     - DB_NAME=postgres
-    - DB_PAS=postgres
+    - DB_PAS=po$$tgres
     - DB_USER=postgres
   links:
   - db


### PR DESCRIPTION
**Issue:**
I have an ecs task definition having environment variables with values containing $(dollar) literals.
container_transform is  not converting them into double-dollar($$) to avoid variable substitution.

**Fixes**
The code changes in this PR fixing this issue and the vice-versa scenario also.
