### PR TITLE
added ECS ulimit support

### DIFF
--- a/container_transform/compose.py
+++ b/container_transform/compose.py
@@ -354,3 +354,9 @@ class ComposeTransformer(BaseTransformer):
 
     def emit_privileged(self, privileged):
         return privileged
+
+    def ingest_ulimits(self, ulimits):
+        return ulimits
+
+    def emit_ulimits(self, ulimits):
+        return ulimits

--- a/container_transform/ecs.py
+++ b/container_transform/ecs.py
@@ -272,7 +272,7 @@ class ECSTransformer(BaseTransformer):
             for volume
             in volumes
             if self._build_mountpoint(volume) is not None
-        ]
+            ]
 
     def ingest_labels(self, labels):
         return labels
@@ -293,3 +293,21 @@ class ECSTransformer(BaseTransformer):
             data['logDriver'] = data.get('driver')
             del data['driver']
         return logging
+
+    def ingest_ulimits(self, ulimits):
+        return ulimits
+
+    def emit_ulimits(self, ulimits):
+        output = []
+        for ulimit_name, ulimit_value in ulimits.items():
+            if type(ulimit_value) is dict:
+                output.append({"name": ulimit_name,
+                               "softLimit": ulimit_value.get('soft'),
+                               "hardLimit": ulimit_value.get('hard')
+                               })
+            else:
+                output.append({"name": ulimit_name,
+                               "softLimit": ulimit_value,
+                               "hardLimit": ulimit_value
+                               })
+        return output

--- a/container_transform/schema.py
+++ b/container_transform/schema.py
@@ -731,6 +731,16 @@ ARG_MAP = OrderedDict({
             'required': False,
         },
     },
+    'ulimits': {
+        TransformationTypes.ECS.value:{
+            'name': "ulimits",
+            'required': False,
+        },
+        TransformationTypes.COMPOSE.value: {
+            'name': "ulimits",
+            'required': False
+        }
+    }
     # TODO create an entry for forcePullImage
     # TODO create an entry for healthChecks
     # TODO create an entry for replicas/instances

--- a/container_transform/systemd.py
+++ b/container_transform/systemd.py
@@ -190,3 +190,9 @@ class SystemdTransformer(BaseTransformer):
 
     def emit_logging(self, logging):
         return logging
+
+    def ingest_ulimits(self, ulimits):
+        pass
+
+    def emit_ulimits(self, ulimits):
+        return ulimits

--- a/container_transform/tests/composev2_extended.yml
+++ b/container_transform/tests/composev2_extended.yml
@@ -14,6 +14,12 @@ services:
       options:
         tag: web
         gelf-address: "udp://127.0.0.1:12900"
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
+
   redis:
     image: redis
     ports:

--- a/container_transform/tests/composev2_extended_output.json
+++ b/container_transform/tests/composev2_extended_output.json
@@ -8,12 +8,12 @@
             "essential": true,
             "image": "redis",
             "name": "redis",
-            "privileged": true,
             "portMappings": [
                 {
                     "containerPort": 6379
                 }
-            ]
+            ],
+            "privileged": true
         },
         {
             "dockerLabels": {
@@ -39,6 +39,20 @@
                 {
                     "containerPort": 5000,
                     "hostPort": 5000
+                }
+            ],
+            "ulimits": [
+                {
+                  "hardLimit": 65535,
+                  "name": "nproc",
+                  "softLimit": 65535
+
+                },
+                {
+                  "hardLimit": 40000,
+                  "name": "nofile",
+                  "softLimit": 20000
+
                 }
             ]
         },

--- a/container_transform/tests/converter_tests.py
+++ b/container_transform/tests/converter_tests.py
@@ -7,7 +7,7 @@ from container_transform.converter import Converter
 class ConverterTests(TestCase):
 
     def test_ecs_converter(self):
-        filename = './container_transform/tests/task.json'
+        filename = './task.json'
         conv = Converter(filename, 'ecs', 'compose')
 
         compose_output = conv.convert()
@@ -17,7 +17,7 @@ class ConverterTests(TestCase):
         self.assertEqual(0, len(conv.messages))
 
     def test_ecs_converter_just_containers(self):
-        filename = './container_transform/tests/containers.json'
+        filename = './containers.json'
         conv = Converter(filename, 'ecs', 'compose')
 
         compose_output = conv.convert()
@@ -27,7 +27,7 @@ class ConverterTests(TestCase):
         self.assertEqual(0, len(conv.messages))
 
     def test_compose_converter_out(self):
-        filename = './container_transform/tests/task.json'
+        filename = './task.json'
         conv = Converter(filename, 'ecs', 'compose')
 
         compose_output = conv.convert()
@@ -37,7 +37,7 @@ class ConverterTests(TestCase):
         self.assertEqual(0, len(conv.messages))
 
     def test_compose_converter_in(self):
-        filename = './container_transform/tests/docker-compose.yml'
+        filename = './docker-compose.yml'
         conv = Converter(filename, 'compose', 'ecs')
 
         output = conv.convert()
@@ -58,21 +58,22 @@ class ConverterTests(TestCase):
     def test_compose_converter_v2_to_ecs(self):
         self.maxDiff = None
 
-        filename = './container_transform/tests/composev2_extended.yml'
-        output_filename = './container_transform/tests/composev2_extended_output.json'
+        filename = './composev2_extended.yml'
+        output_filename = './composev2_extended_output.json'
         conv = Converter(filename, 'compose', 'ecs')
 
         output = conv.convert()
         output_dict = json.loads(output)
 
         output_want = json.load(open(output_filename, 'r'))
+
         self.assertDictEqual(output_dict, output_want)
 
     def test_compose_converter_v2_systemd(self):
         self.maxDiff = None
 
-        filename = './container_transform/tests/composev2.yml'
-        output_filename = './container_transform/tests/composev2_output.service'
+        filename = './composev2.yml'
+        output_filename = './composev2_output.service'
         conv = Converter(filename, 'compose', 'systemd')
 
         output = conv.convert()
@@ -83,8 +84,8 @@ class ConverterTests(TestCase):
     def test_compose_converter_v2_0(self):
         self.maxDiff = None
 
-        filename = './container_transform/tests/composev2.0.yml'
-        output_filename = './container_transform/tests/composev2.0_output.service'
+        filename = './composev2.0.yml'
+        output_filename = './composev2.0_output.service'
         conv = Converter(filename, 'compose', 'systemd')
 
         output = conv.convert()

--- a/container_transform/transformer.py
+++ b/container_transform/transformer.py
@@ -32,6 +32,7 @@ SCHEMA = {
     'env-file': list,
     'pid': str,
     'fetch': [dict],
+    'ulimit': dict
 }
 
 
@@ -270,4 +271,12 @@ class BaseTransformer(object, metaclass=ABCMeta):
 
     @abstractmethod
     def emit_volumes(self, volumes):
+        raise NotImplementedError
+
+    @abstractmethod
+    def ingest_ulimits(self, ulimits):
+        raise NotImplementedError
+
+    @abstractmethod
+    def emit_ulimits(self, ulimits):
         raise NotImplementedError


### PR DESCRIPTION
- fixed the test data file path issue
- added Docker Compose to  ECS ulimit support

docker-compose input
```
    ulimits:
      nproc: 65535
      nofile:
        soft: 20000
        hard: 40000
```

ECS task definition output
```
            "ulimits": [
                {
                  "hardLimit": 65535,
                  "name": "nproc",
                  "softLimit": 65535

                },
                {
                  "hardLimit": 40000,
                  "name": "nofile",
                  "softLimit": 20000

                }
            ]
```

