### PR TITLE
memory is an integer - v1.1.6

### DIFF
--- a/container_transform/chronos.py
+++ b/container_transform/chronos.py
@@ -268,7 +268,7 @@ class ChronosTransformer(BaseTransformer):
             in port_mappings]
 
     def ingest_memory(self, memory):
-        return memory << 20
+        return int(memory) << 20
 
     def emit_memory(self, memory):
         mem_in_mb = memory >> 20

--- a/container_transform/kubernetes.py
+++ b/container_transform/kubernetes.py
@@ -162,7 +162,7 @@ class KubernetesTransformer(BaseTransformer):
 
         output = {
             'kind': 'Deployment',
-            'apiVersion': 'extensions/v1beta1',
+            'apiVersion': 'apps/v1',
             'metadata': {
                 'name': None,
                 'namespace': 'default',

--- a/container_transform/marathon.py
+++ b/container_transform/marathon.py
@@ -279,7 +279,7 @@ class MarathonTransformer(BaseTransformer):
             in port_mappings]
 
     def ingest_memory(self, memory):
-        return memory << 20
+        return int(memory) << 20
 
     def emit_memory(self, memory):
         mem_in_mb = memory >> 20


### PR DESCRIPTION
* Memory is an integer, not a float. 
* `Deployment` should use _apiVersion: apps/v1_

```bash
  File "/usr/local/lib/python3.6/site-packages/container_transform-1.1.5-py3.6.egg/container_transform/marathon.py", line 282, in ingest_memory
    return memory << 20
TypeError: unsupported operand type(s) for <<: 'float' and 'int'
```

Signed-off-by: Jake Plimack <jake.plimack@gmail.com>